### PR TITLE
Merge release 1.0.0 into master

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+### 1.0.0
+- Add CI integration and tests ([#2](https://github.com/AvdLee/Poes/pull/2)) via @AvdLee
+
 ### 0.1.0
 
 - Initial setup


### PR DESCRIPTION
Containing all the changes for our [**1.0.0 Release**](Warning: Permanently added 'github.com,140.82.114.4' (RSA) to the list of known hosts.
The operation couldn’t be completed. (com.nerdishbynature.octokit error 404.)
).